### PR TITLE
Fix saving of mobile phone number

### DIFF
--- a/src/Server/OneTrueError.Web/Views/User/Settings.html
+++ b/src/Server/OneTrueError.Web/Views/User/Settings.html
@@ -23,9 +23,9 @@
                 </div>
             </div>
             <div class="form-group">
-                <label for="CellNumber" class="col-sm-2 control-label">Cellphone Number</label>
+                <label for="MobileNumber" class="col-sm-2 control-label">Cellphone Number</label>
                 <div class="col-sm-10">
-                    <input type="text" class="form-control" id="CellNumber" placeholder="Cellphone number" data-name="CellNumber">
+                    <input type="text" class="form-control" id="MobileNumber" placeholder="Cellphone number" data-name="MobileNumber">
                     <p class="help-block">Use E.164 format (+&lt;countryCode&gt;&lt;number&gt;). Example: +4670123456</p>
                 </div>
             </div>


### PR DESCRIPTION
SettingsViewModel.ts contains a reference to `dto.MobileNumber` but Settings.html contains `data-name="CellNumber"`. I think those two should be the same. Based on the schema I'd say MobileNumber is the right name.